### PR TITLE
Jtwig-375: update guava to fix a known issue (CVE-2018-10237)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ buildscript {
 dependencies {
     compile "org.jtwig:jtwig-core:$jtwigVersion"
 
-    compile 'com.google.guava:guava:18.0'
+    compile 'com.google.guava:guava:28.0-jre'
     compile 'org.apache.commons:commons-lang3:3.1'
     compile 'org.slf4j:slf4j-api:1.7.12'
     compile 'org.apache.httpcomponents:httpclient:4.4.1'


### PR DESCRIPTION
Fixes jtwig/jtwig#375